### PR TITLE
Added support for SSL to API calls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 - '2.7'
 - '3.2'
 - '3.3'
+- '3.4'
 
 before_install:
 - sudo apt-get update -qq

--- a/osmapi/OsmApi.py
+++ b/osmapi/OsmApi.py
@@ -39,11 +39,11 @@ import sys
 import urllib
 from datetime import datetime
 
+from osmapi import __version__
+
 # Python 3.x
 if getattr(urllib, 'urlencode', None) is None:
     urllib.urlencode = urllib.parse.urlencode
-
-from osmapi import __version__
 
 
 class UsernamePasswordMissingError(Exception):

--- a/osmapi/OsmApi.py
+++ b/osmapi/OsmApi.py
@@ -95,7 +95,7 @@ class OsmApi:
             passwordfile=None,
             appid="",
             created_by="osmapi/"+__version__,
-            api="www.openstreetmap.org",
+            api="https://www.openstreetmap.org",
             changesetauto=False,
             changesetautotags={},
             changesetautosize=500,
@@ -1773,7 +1773,12 @@ class OsmApi:
                 self._conn = self._get_http_connection()
 
     def _get_http_connection(self):
-        return httplib.HTTPConnection(self._api, 80)
+        if self._api.lower().startswith('https://'):
+            return httplib.HTTPSConnection(self._api[8:], 443)
+        elif self._api.lower().startswith('http://'):
+            return httplib.HTTPConnection(self._api[7:], 80)
+        else:
+            return httplib.HTTPConnection(self._api, 80)
 
     def _sleep(self):
         time.sleep(5)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import codecs
+from distutils.core import setup
 
 version = __import__('osmapi').__version__
 
@@ -13,7 +14,6 @@ try:
 except (IOError, ImportError):
     description = 'Python wrapper for the OSM API'
 
-from distutils.core import setup
 setup(
     name='osmapi',
     packages=['osmapi'],


### PR DESCRIPTION
This pull request adds SSL encryption to API calls, which the default OSM API server supports.

SSL can be enabled by adding the "https://" prefix to the `api` parameter in `OsmApi.__init__`. I have also set the `api` parameter default to use SSL by default.

Let me know if you need me to make any documentation updates.