### PR TITLE
Add requests dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     name='osmapi',
     packages=['osmapi'],
     version=version,
+    install_requires=['requests'],
     description='Python wrapper for the OSM API',
     long_description=description,
     author='Etienne Chové',


### PR DESCRIPTION
as I learned from https://caremad.io/posts/2013/07/setup-vs-requirement/
a dependency that is needed to run a library should be added as a
install_requires statement in the setup.py in order to tell pip to
install it when it is required in another project.