### PR TITLE
Add support for Python 3.7 and remove Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,22 @@ language: python
 
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
 - '3.6'
+
+matrix:
+  include:
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+    sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq pandoc
 
 install:
-- pip install -r requirements.txt
-- pip install -r test-requirements.txt
-- pip install .
+- pip install -r requirements.txt -r test-requirements.txt
 
 script: ./build.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 
 install:
 - pip install -r requirements.txt -r test-requirements.txt
+- pip install .
 
 script: ./build.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,5 @@ deploy:
     on:
       tags: true
       all_branches: true
-      python: 2.7
+      python: 3.7
       repo: metaodi/osmapi

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To test this library, please create an account on the [development server of Ope
 ```python
 import osmapi
 api = osmapi.OsmApi()
-print api.NodeGet(123)
+print(api.NodeGet(123))
 # {u'changeset': 532907, u'uid': 14298,
 # u'timestamp': u'2007-09-29T09:19:17Z',
 # u'lon': 10.790009299999999, u'visible': True,
@@ -59,7 +59,7 @@ Note: Each line in the password file should have the format _user:password_
 import osmapi
 api = osmapi.OsmApi(api="https://api06.dev.openstreetmap.org", username = u"metaodi", password = u"*******")
 api.ChangesetCreate({u"comment": u"My first test"})
-print api.NodeCreate({u"lon":1, u"lat":1, u"tag": {}})
+print(api.NodeCreate({u"lon":1, u"lat":1, u"tag": {}}))
 # {u'changeset': 532907, u'lon': 1, u'version': 1, u'lat': 1, u'tag': {}, u'id': 164684}
 api.ChangesetClose()
 ```
@@ -87,7 +87,7 @@ To run the tests use the following command:
 
     nosetests --verbose
 
-By using tox you can even run the tests against different versions of python (2.7, 3.3, 3.4, 3.5 and 3.6):
+By using tox you can even run the tests against different versions of python (2.7, 3.4, 3.5, 3.6 and 3.7):
 
     tox
 

--- a/osmapi/OsmApi.py
+++ b/osmapi/OsmApi.py
@@ -213,10 +213,10 @@ class OsmApi:
         if password:
             self._password = password
         elif passwordfile:
-            for l in open(passwordfile).readlines():
-                l = l.strip().split(":")
-                if l[0] == self._username:
-                    self._password = l[1]
+            for line in open(passwordfile).readlines():
+                line = line.strip().split(":")
+                if line[0] == self._username:
+                    self._password = line[1]
 
         # Changest informations
         # auto create and close changesets
@@ -308,7 +308,7 @@ class OsmApi:
             for k, v in elem.attributes.items():
                 try:
                     result[elem.nodeName][k] = float(v)
-                except:
+                except Exception:
                     result[elem.nodeName][k] = v
         return result
 
@@ -2223,10 +2223,10 @@ class OsmApi:
         result = DateString
         try:
             result = datetime.strptime(DateString, "%Y-%m-%d %H:%M:%S UTC")
-        except:
+        except Exception:
             try:
                 result = datetime.strptime(DateString, "%Y-%m-%dT%H:%M:%SZ")
-            except:
+            except Exception:
                 pass
 
         return result
@@ -2296,5 +2296,5 @@ class OsmApi:
         try:
             elem = DomElement.getElementsByTagName(tag)[0]
             return elem.firstChild.nodeValue
-        except:
+        except Exception:
             return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # This file lists the dependencies of this extension.
 # Install with a command like: pip install -r pip-requirements.txt
-pypandoc==0.7.0
-Unidecode==0.04.14
-pdoc==0.3.1
-Pygments==1.6
-requests==2.8.0
+pdoc==0.3.2
+Pygments==2.2.0
+pypandoc==1.4
+requests==2.20.0
+Unidecode==1.0.22

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,11 +1,10 @@
 # This file lists the dependencies of this extension.
 # Install with a command like: pip install -r pip-requirements.txt
-flake8==3.0.4; python_version >= '2.7'
-flake8==2.1.0; python_version == '2.6'
-nose==1.3.0
-tox==2.8.1
-coverage==3.7.1
-coveralls==0.4.1
-mock==1.0.1
-xmltodict==0.9.0
-virtualenv==15.1.0
+coverage==4.5.1
+coveralls==1.5.1
+flake8==3.6.0
+mock==2.0.0
+nose==1.3.7
+tox==3.5.3
+virtualenv==16.1.0
+xmltodict==0.11.0

--- a/tests/changeset_tests.py
+++ b/tests/changeset_tests.py
@@ -6,7 +6,7 @@ import xmltodict
 import datetime
 try:
     import urlparse
-except:
+except Exception:
     import urllib
     urlparse = urllib.parse
 
@@ -23,7 +23,7 @@ def recursive_sort(col):  # noqa
                 col = sorted(col)
             except TypeError:  # in Python 3.x: lists of dicts are not sortable
                 col = sorted(col, key=lambda k: hash(frozenset(k.items())))
-            except:
+            except Exception:
                 pass
 
             for idx, elem in enumerate(col):

--- a/tests/osmapi_tests.py
+++ b/tests/osmapi_tests.py
@@ -64,7 +64,7 @@ class TestOsmApi(unittest.TestCase):
             try:
                 with open(path) as file:
                     return_values.append(file.read())
-            except:
+            except Exception:
                 pass
         return return_values
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36
+envlist = py27,py34,py35,py36,py37
 [testenv]
 commands=nosetests --verbose
 deps =


### PR DESCRIPTION
* Add Python 3.7 to Travis CI, Tox, and the trove classifiers in setup.py
* Remove Python 3.3. in the same places because it is already EOL.
* Update all requirements to ensure compatibility with Python 3.7.
* Fix the issues raised by the newer versions of flake8