### PR TITLE
Add support for OAuth1

### DIFF
--- a/osmapi/OsmApi.py
+++ b/osmapi/OsmApi.py
@@ -203,7 +203,9 @@ class OsmApi:
         # debug
         self._debug = debug
 
-        if auth_session:
+        self._auth_session = auth_session
+
+        if self._auth_session:
             self._auth_session = auth_session
         else:
             # Get username


### PR DESCRIPTION
Hey there! This is an attempt to add Oauth1.0{a} support to `OsmAPI`
I think the `requests` based OAuth1 implementations are quite popular in Python and maybe we can make OsmAPI support a previously authenticated `Session` object to be used directly instead of making more complex changes into this library.

 ```python
from osmapi import OsmApi
from authlib.integrations.requests_client import OAuth1Session
...
# let's assume we already did all the `request_token`, `authorize` and `access_token` dance(workflow) from OAuth1
# so we already have consumer_key, consumer_secret, oauth_token, and oauth_token_secret
oauth_session = OAuth1Session(client_id=consumer_key,
                      client_secret=consumer_secret,
                      token=oauth_token,
                      token_secret=oauth_token_secret)

# with this PR we can just do
osm = OsmApi(auth_session=self.auth_session) # already authenticated `Requests.Session`
changeset_id = osm.ChangesetCreate({"comment": "this is already authenticated", "created_by": "SomeAwesomeApp/0.1")
# ... Do some cool stuff here with osm
osm.ChangesetClose()
```

I know I didn't provide proper unit test, but I wasn't sure how to do this, as OAuth1.0 workflow is quite complex, if you can give me some ideas I will be glad to implement them.

So what do you think? Won't be nice to have OsmAPI with OAuth1.0{a} support? If you think there is anything I can improve let me know.  