### PR TITLE
Replace the readme oauth2 example with a cli-oauth2 based one

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,65 +71,41 @@ Note: Each line in the password file should have the format _user:password_
 
 ### OAuth authentication
 
-Username/Password authentication will be deprecated in 2024 (see [official OWG announcemnt](https://www.openstreetmap.org/user/pnorman/diary/401157) for details).
+Username/Password authentication will be deprecated in July 2024
+(see [official OWG announcemnt](https://blog.openstreetmap.org/2024/04/17/oauth-1-0a-and-http-basic-auth-shutdown-on-openstreetmap-org/) for details).
 In order to use this library in the future, you'll need to use OAuth 2.0.
 
-To use OAuth 2.0, you must register an application with an OpenStreetMap account, either on the [development server](https://master.apis.dev.openstreetmap.org/oauth2/applications) or on the [production server](https://www.openstreetmap.org/oauth2/applications).
+To use OAuth 2.0, you must register an application with an OpenStreetMap account, either on the
+[development server](https://master.apis.dev.openstreetmap.org/oauth2/applications)
+or on the [production server](https://www.openstreetmap.org/oauth2/applications).
 Once this registration is done, you'll get a `client_id` and a `client_secret` that you can use to authenticate users.
 
-Example code using [`requests-oauth2client`](https://pypi.org/project/requests-oauth2client/):
+Example code using [`cli-oauth2`](https://github.com/Zverik/cli-oauth2):
 
 ```python
-from requests_oauth2client import OAuth2Client, OAuth2AuthorizationCodeAuth
-import requests
-import webbrowser
 import osmapi
-import os
+from oauthcli import OpenStreetMapAuth
 
 client_id = "<client_id>"
 client_secret = "<client_secret>"
 
-# special value for redirect_uri for non-web applications
-redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
+auth = OpenStreetMapDevAuth(
+    client_id, client_secret, ['read_prefs', 'write_map']
+).auth_server()
 
-authorization_base_url = "https://master.apis.dev.openstreetmap.org/oauth2/authorize"
-token_url = "https://master.apis.dev.openstreetmap.org/oauth2/token"
-
-oauth2client = OAuth2Client(
-    token_endpoint=token_url,
-    authorization_endpoint=authorization_base_url,
-    redirect_uri=redirect_uri,
-    client_id=client_id,
-    client_secret=client_secret,
-    code_challenge_method=None,
-)
-
-# open OSM website to authrorize user using the write_api and write_notes scope
-scope = ["write_api", "write_notes"]
-az_request = oauth2client.authorization_request(scope=scope)
-print(f"Authorize user using this URL: {az_request.uri}")
-webbrowser.open(az_request.uri)
-
-# create a new requests session using the OAuth authorization
-auth_code = input("Paste the authorization code here: ")
-auth = OAuth2AuthorizationCodeAuth(
-    oauth2client,
-    auth_code,
-    redirect_uri=redirect_uri,
-)
-oauth_session = requests.Session()
-oauth_session.auth = auth
-
-# use the custom session
 api = osmapi.OsmApi(
     api="https://api06.dev.openstreetmap.org",
-    session=oauth_session
+    session=auth.session
 )
+
 with api.Changeset({"comment": "My first test"}) as changeset_id:
     print(f"Part of Changeset {changeset_id}")
     node1 = api.NodeCreate({"lon": 1, "lat": 1, "tag": {}})
     print(node1)
 ```
+
+An alternative way using the `requests-oauthlib` library can be found
+[in the examples](https://github.com/metaodi/osmapi/blob/develop/examples/oauth2.py).
 
 ## Note about imports / automated edits
 


### PR DESCRIPTION
This is a follow-up to #168. Prompts for a simple way to use OAuth2 with this library.