### PR TITLE
Fix mock content initialization in test fixtures

### DIFF
--- a/osmapi/OsmApi.py
+++ b/osmapi/OsmApi.py
@@ -25,6 +25,7 @@ Find all information about changes of the different versions of this module
 * Since version 5.0 of this library, all method names are in snake_case,
 the CamelCase versions are deprecated and will be removed in version 6.0.
 """
+
 import re
 import logging
 import warnings

--- a/tests/capabilities_test.py
+++ b/tests/capabilities_test.py
@@ -19,6 +19,6 @@ class TestOsmApiNode(osmapi_test.TestOsmApi):
         )
 
     def test_Capabilities_deprecation_warning(self):
-        self._session_mock()
+        self._session_mock(filenames=["test_Capabilities.xml"])
         with self.assertWarns(DeprecationWarning):
             self.api.Capabilities()

--- a/tests/osmapi_test.py
+++ b/tests/osmapi_test.py
@@ -24,6 +24,8 @@ class TestOsmApi(unittest.TestCase):
         assert len(return_values) < 2
         if return_values:
             response_mock.content = return_values[0]
+        else:
+            response_mock.content = ""
 
         self.session_mock = mock.Mock()
         self.session_mock.request = mock.Mock(return_value=response_mock)
@@ -53,7 +55,46 @@ class TestOsmApi(unittest.TestCase):
                 with codecs.open(path, "r", "utf-8") as file:
                     return_values.append(file.read())
             except Exception:
-                pass
+                # Try case-insensitive match for backward compatibility
+                # Also try converting snake_case to CamelCase
+                # (e.g., test_way_get -> test_WayGet)
+                try:
+                    fixture_dir = os.path.join(__location__, "fixtures")
+                    available_files = os.listdir(fixture_dir)
+
+                    # First try exact case-insensitive match
+                    for available_file in available_files:
+                        if available_file.lower() == filename.lower():
+                            path = os.path.join(fixture_dir, available_file)
+                            with codecs.open(path, "r", "utf-8") as file:
+                                return_values.append(file.read())
+                            break
+                    else:
+                        # Try snake_case to CamelCase conversion
+                        # e.g., test_way_get.xml -> test_WayGet.xml
+                        # Split on underscore, then capitalize each word
+                        # except the first
+                        base_name, ext = os.path.splitext(filename)
+                        parts = base_name.split("_")
+                        if len(parts) > 1:
+                            # Keep first part as-is, capitalize the rest
+                            camel_case_base = (
+                                parts[0]
+                                + "_"
+                                + "".join(p.capitalize() for p in parts[1:])
+                            )
+                            camel_case_filename = camel_case_base + ext
+                            for available_file in available_files:
+                                if (
+                                    available_file.lower()
+                                    == camel_case_filename.lower()
+                                ):
+                                    path = os.path.join(fixture_dir, available_file)
+                                    with codecs.open(path, "r", "utf-8") as file:
+                                        return_values.append(file.read())
+                                    break
+                except Exception:
+                    pass
         return return_values
 
     def teardown(self):


### PR DESCRIPTION
This commit addresses test failures caused by mock objects being passed to XML parsing functions. The issue occurred when test fixture files couldn't be found, leaving response_mock.content uninitialized as a Mock object instead of bytes/string.

Changes:
1. Initialize response_mock.content to empty string when no fixture file is found, preventing TypeError in XML parsing
2. Add fallback logic to handle fixture file naming mismatches between snake_case test method names and CamelCase fixture files
3. Implement case-insensitive fixture file lookup for backward compatibility
4. Fix black formatting issue in osmapi/OsmApi.py (add blank line after module docstring)
5. Update test_Capabilities_deprecation_warning to explicitly specify fixture file

The fixture lookup now tries multiple strategies:
- Exact filename match
- Case-insensitive match
- snake_case to CamelCase conversion (e.g., test_way_get.xml -> test_WayGet.xml)

This fixes the test_Capabilities_deprecation_warning test and many other tests that were failing due to fixture file naming mismatches after the snake_case refactoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)