### PR TITLE
Fix TypeError in changeset_upload when handling HTTP 409 responses

### DIFF
--- a/osmapi/changeset.py
+++ b/osmapi/changeset.py
@@ -213,8 +213,13 @@ class ChangesetMixin:
                 forceAuth=True,
             )
         except errors.ApiError as e:
+            payload_str = (
+                e.payload.decode("utf-8", errors="replace")
+                if isinstance(e.payload, bytes)
+                else str(e.payload)
+            )
             if e.status == 409 and re.search(
-                r"The changeset .* was closed at .*", e.payload
+                r"The changeset .* was closed at .*", payload_str
             ):
                 raise errors.ChangesetClosedApiError(
                     e.status, e.reason, e.payload

--- a/tests/changeset_test.py
+++ b/tests/changeset_test.py
@@ -508,6 +508,54 @@ def test_changeset_upload_no_auth(api):
     assert str(execinfo.value) == "Username/Password missing"
 
 
+def test_changeset_upload_version_mismatch_raises_api_error(auth_api, add_response):
+    """HTTP 409 version mismatch must raise ApiError, not TypeError."""
+    add_response(PUT, "/changeset/create", body="4444")
+    add_response(
+        POST,
+        "/changeset/4444/upload",
+        body=b"Version mismatch: Provided 3, server had: 4",
+        status=409,
+    )
+
+    changesdata = [
+        {
+            "type": "node",
+            "action": "modify",
+            "data": [{"id": 1, "version": 3, "lat": 47.0, "lon": 8.0, "tag": {}}],
+        }
+    ]
+
+    auth_api.changeset_create()
+    with pytest.raises(osmapi.errors.ApiError) as execinfo:
+        auth_api.changeset_upload(changesdata)
+    assert execinfo.value.status == 409
+    assert b"Version mismatch" in execinfo.value.payload
+
+
+def test_changeset_upload_closed_changeset_raises_correct_error(auth_api, add_response):
+    """HTTP 409 'changeset closed' must raise ChangesetClosedApiError."""
+    add_response(PUT, "/changeset/create", body="4444")
+    add_response(
+        POST,
+        "/changeset/4444/upload",
+        body=b"The changeset 4444 was closed at 2024-01-01T00:00:00Z",
+        status=409,
+    )
+
+    changesdata = [
+        {
+            "type": "node",
+            "action": "modify",
+            "data": [{"id": 1, "version": 1, "lat": 47.0, "lon": 8.0, "tag": {}}],
+        }
+    ]
+
+    auth_api.changeset_create()
+    with pytest.raises(osmapi.errors.ChangesetClosedApiError):
+        auth_api.changeset_upload(changesdata)
+
+
 def test_changeset_download(api, add_response):
     # Setup mock
     add_response(GET, "/changeset/23123/download")


### PR DESCRIPTION
`changeset_upload` applies a string regex pattern against `e.payload`, which is bytes (set from `response.content.strip()` in `http.py`). This raises a `TypeError` on every HTTP 409 response, masking the original `ApiError` and making version mismatches, closed `changesets`, and other conflicts appear as unrelated crashes.

Fix: decode `e.payload` to `str` before the `re.search` call, with a safe fallback for the few code paths that already pass a `str` payload (timeouts, connection errors).

Two regression tests are added:
- a version-mismatch 409 must bubble up as `ApiError`, not `TypeError`
- a closed-changeset 409 must still raise `ChangesetClosedApiError`
