### PR TITLE
Fix release trigger for Upload Python Package workflow

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -2,7 +2,13 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build and publish (e.g. v5.1.0)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -17,6 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.tag || github.ref }}
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -42,6 +50,8 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.tag || github.ref }}
     - name: Set up Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
The workflow listened for `release: [created]`, which is not emitted to
Actions when a release is saved as a draft first and published later —
publishing a draft emits `published`/`released` instead. That is why the
v5.1.0 release did not trigger a PyPI upload while v5.0.0 (published
directly, without a draft step) did.

- Switch the trigger to `release: [published]`, which fires for both
  direct publishes and drafts that are later published.
- Add a `workflow_dispatch` trigger with a required `tag` input so a
  release can be built and uploaded manually, e.g. to recover v5.1.0.
- Check out `inputs.tag || github.ref` so manual runs build the given
  tag while release runs keep building the released tag.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013jGk6zoz2S9i98dZgiqttr