### PR TITLE
Update CLAUDE.md for the uv/pyproject.toml layout and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Python dependencies: pyproject.toml + uv.lock
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      # Runtime dependencies get their own PR, dev tooling is bundled
+      dev-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+
+  # Actions used in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Hook revisions in .pre-commit-config.yaml
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 - Test against Python 3.13 and 3.14 in CI
+- Add a Dependabot config (`.github/dependabot.yml`) with weekly updates for the `uv`, `github-actions` and `pre-commit` ecosystems
 
 ### Removed
 - **BC-Break**: Removed all deprecated `CamelCase` methods (e.g. `NodeGet`, `ChangesetCreate`, `NotesGet`, `Map`, `Capabilities`), they have been deprecated since 5.0. Use the `snake_case` equivalents instead (e.g. `node_get`, `changeset_create`, `notes_get`, `map`, `capabilities`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - Test against Python 3.13 and 3.14 in CI
 - Add a Dependabot config (`.github/dependabot.yml`) with weekly updates for the `uv`, `github-actions` and `pre-commit` ecosystems
+- Declare a minimum version for the `requests` dependency (`requests>=2.25.0`), no upper bound is set
 
 ### Removed
 - **BC-Break**: Removed all deprecated `CamelCase` methods (e.g. `NodeGet`, `ChangesetCreate`, `NotesGet`, `Map`, `Capabilities`), they have been deprecated since 5.0. Use the `snake_case` equivalents instead (e.g. `node_get`, `changeset_create`, `notes_get`, `map`, `capabilities`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,11 @@ It is a library (no CLI, no server), published on [PyPI](https://pypi.python.org
 - Runtime dependency: **`requests` only** (`[project] dependencies`). Do not add new runtime dependencies
   without a very good reason — everything in `[dependency-groups]` (`dev`, `docs`, `lint`, `test`) is
   dev/test tooling.
+- Version constraints: runtime deps get a **lower bound only** — never cap a dependency (`<`) in a library,
+  the cap propagates into every downstream resolver. Dev tools get `>=` floors at the versions currently
+  locked, except `black`, `pdoc` and `Pygments`, which are pinned exactly because a bump rewrites the whole
+  code base / the committed `docs/`. Constraints also matter for Dependabot: it skips dependencies declared
+  without any specifier, so a new dependency needs at least a floor to be tracked.
 - Supported Python: **>= 3.10** (CI matrix: 3.10, 3.11, 3.12, 3.13, 3.14).
 - License: GPLv3. Originally written by Etienne Chové, maintained by Stefan Oderbolz (metaodi).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,13 @@ Guidance for AI assistants working in this repository.
 It is a library (no CLI, no server), published on [PyPI](https://pypi.python.org/pypi/osmapi) and documented at
 <http://osmapi.metaodi.ch> (GitHub Pages, served from the `main` branch via `docs/` + `CNAME`).
 
-- Runtime dependency: **`requests` only** (`setup.py` `install_requires`). Do not add new runtime dependencies
-  without a very good reason — everything else in `test-requirements.txt` is dev/test tooling.
-- Supported Python: **>= 3.9** (CI matrix: 3.9, 3.10, 3.11, 3.12).
+- Packaging: PEP 621 `pyproject.toml` (setuptools backend), dependencies and virtual env managed with
+  [uv](https://docs.astral.sh/uv/); `uv.lock` is committed. There is no `setup.py`, `setup.cfg` or
+  `requirements.txt` anymore.
+- Runtime dependency: **`requests` only** (`[project] dependencies`). Do not add new runtime dependencies
+  without a very good reason — everything in `[dependency-groups]` (`dev`, `docs`, `lint`, `test`) is
+  dev/test tooling.
+- Supported Python: **>= 3.10** (CI matrix: 3.10, 3.11, 3.12, 3.13, 3.14).
 - License: GPLv3. Originally written by Etienne Chové, maintained by Stefan Oderbolz (metaodi).
 
 ## Repository layout
@@ -35,6 +39,10 @@ tests/             pytest suite + tests/fixtures/*.xml recorded API responses
 examples/          runnable usage examples (oauth2, changesets, notes, timeout, ...)
 docs/              pdoc-generated HTML, committed to the repo (published via GitHub Pages)
 .github/workflows/ build.yml (CI) and publish_python.yml (PyPI release)
+.github/           dependabot.yml (weekly uv / github-actions / pre-commit updates)
+pyproject.toml     packaging metadata, dependency groups, mypy config
+uv.lock            the locked dev environment (committed)
+.flake8            flake8 config (max-complexity, line length, E203 ignore)
 ```
 
 ## Architecture
@@ -47,8 +55,8 @@ class OsmApi(NodeMixin, WayMixin, RelationMixin, ChangesetMixin, NoteMixin, Capa
 
 Every mixin method is annotated `self: "OsmApi"` (with `from .OsmApi import OsmApi` under
 `if TYPE_CHECKING:`) so mypy resolves the cross-mixin attribute access. Keep that pattern when adding methods.
-`setup.cfg` disables mypy's `misc` error code per-mixin-module — that is what makes the `self: "OsmApi"`
-annotation acceptable; don't "fix" it by removing the annotations.
+The `[[tool.mypy.overrides]]` block in `pyproject.toml` disables mypy's `misc` error code per-mixin-module —
+that is what makes the `self: "OsmApi"` annotation acceptable; don't "fix" it by removing the annotations.
 
 Request/response flow for a typical call:
 
@@ -96,24 +104,29 @@ and list every exception the method can raise ("If the requested element has bee
 
 ## Development workflow
 
+Everything runs through [uv](https://docs.astral.sh/uv/) — the `make` targets wrap `uv run`, so there is no
+venv to activate manually:
+
 ```bash
-./setup.sh          # create ./pyenv venv, install deps + this package editable
-make deps           # install requirements + test-requirements, install pre-commit hooks
-make format         # black over osmapi examples tests *.py
-make lint           # black --check, flake8, mypy osmapi
-make test           # pytest --cov=osmapi tests/
+./setup.sh          # just calls `make deps`
+make deps           # uv sync (creates ./.venv) + uv run pre-commit install
+make format         # black over osmapi examples tests
+make lint           # black --check, flake8 ., mypy osmapi
+make test           # pytest --cov=osmapi tests/ (in UTF-8 mode)
 make coverage       # coverage run + report
 make docs           # pdoc -o docs osmapi  (regenerates the committed docs/)
-./test.sh           # what CI runs: lint + test + docs + install into a fresh virtualenv
+make build          # uv build (wheel + sdist into dist/)
+./test.sh           # what CI runs: lint + test + docs + build + import from the built wheel
 ```
 
-Style rules: **black** (line length 88), flake8 with `max-complexity = 10` and `extend-ignore = E203`
-(see `setup.cfg`). Functions that legitimately exceed the complexity limit carry `# noqa: C901` —
-prefer refactoring, but the marker is accepted for the big dispatch functions.
-`pre-commit` runs black, flake8 and mypy; `make deps` installs the hooks.
+Use `uv run <cmd>` for one-off commands and `uv run --python 3.13 ...` to try another interpreter;
+`uv add` / `uv add --group <group>` when a dependency really has to change (that also updates `uv.lock`).
 
-Note: `CONTRIBUTING.md` is outdated (it mentions `nosetests`, `tox` and Travis CI). The commands above and
-`.github/workflows/build.yml` are the source of truth.
+Style rules: **black** (line length 88), flake8 with `max-complexity = 10` and `extend-ignore = E203`
+(see `.flake8`). Functions that legitimately exceed the complexity limit carry `# noqa: C901` —
+prefer refactoring, but the marker is accepted for the big dispatch functions.
+`pre-commit` runs black, flake8 and mypy (the hook points at `--config-file=pyproject.toml`);
+`make deps` installs the hooks.
 
 ## Tests
 
@@ -135,7 +148,12 @@ Note: `CONTRIBUTING.md` is outdated (it mentions `nosetests`, `tox` and Travis C
 
 - `develop` is the integration branch and the **default target for pull requests**; `main` holds releases and
   the published documentation.
-- CI (`build.yml`) runs `./test.sh` on every PR and on pushes to `main`/`develop`, across Python 3.9–3.12.
+- CI (`build.yml`) runs `./test.sh` on every PR and on pushes to `main`/`develop`, across Python 3.10–3.14
+  (`astral-sh/setup-uv` + `uv sync`).
+- Dependabot (`.github/dependabot.yml`) opens weekly PRs against `develop` for the `uv`, `github-actions`
+  and `pre-commit` ecosystems; dev-dependency bumps are grouped into a single PR, runtime bumps are not.
+- The version lives **only** in `osmapi/__init__.py`; `pyproject.toml` reads it via
+  `[tool.setuptools.dynamic] version = { attr = "osmapi.__version__" }`.
 - Release steps (see README): bump `__version__` in `osmapi/__init__.py`, update `CHANGELOG.md`,
   run `make docs`, PR `develop` -> `main`, then publish a GitHub release/tag — `publish_python.yml`
   builds and uploads to PyPI via trusted publishing on `release: published` (or manual `workflow_dispatch`
@@ -155,5 +173,7 @@ Note: `CONTRIBUTING.md` is outdated (it mentions `nosetests`, `tox` and Travis C
   (the `changeset()` context manager wraps both). `changeset_update`, `changeset_close`, `changeset_upload`
   and every element write require it to be non-zero, otherwise `NoChangesetOpenError` is raised;
   `changeset_create` raises `ChangesetAlreadyOpenError` if one is already open.
-- mypy prints a warning that `python_version = 3.9` in `setup.cfg` is unsupported by the installed mypy —
-  it still succeeds; that is expected, not a failure.
+- `black` is pinned twice — `[dependency-groups] lint` in `pyproject.toml` and `rev:` in
+  `.pre-commit-config.yaml`. Bump both together, otherwise `make lint` and the hook disagree on formatting.
+- Don't hand-edit `uv.lock`; change `pyproject.toml` and run `uv sync` (or use `uv add`) so the lock is
+  regenerated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,10 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["requests"]
+# Lower bound only: osmapi only uses the long-stable parts of the requests API
+# (Session, Session.request and the exception classes). Never add an upper bound
+# here, a cap in a library propagates into every downstream resolver.
+dependencies = ["requests>=2.25.0"]
 dynamic = ["version"]
 
 [project.urls]
@@ -37,17 +40,22 @@ dev = [
     { include-group = "docs" },
     { include-group = "lint" },
     { include-group = "test" },
-    "pre-commit",
+    "pre-commit>=4.6",
 ]
+# pdoc and Pygments are pinned exactly: they render the committed docs/ HTML,
+# a bump rewrites every file in there and should be its own reviewable change.
 docs = ["pdoc==14.5.1", "Pygments==2.20.0"]
-lint = ["black==26.3.1", "flake8", "mypy", "types-requests"]
+# black is pinned exactly (and must match the rev in .pre-commit-config.yaml),
+# a bump reformats the whole code base. The flake8/mypy floors keep the local
+# tools from being older than the versions the pre-commit hooks run.
+lint = ["black==26.3.1", "flake8>=7.3", "mypy>=2.3", "types-requests>=2.33"]
 test = [
-    "pytest",
-    "pytest-cov",
-    "coverage",
-    "responses",
-    "xmltodict",
-    "python-dotenv",
+    "pytest>=9.1",
+    "pytest-cov>=7.1",
+    "coverage>=7.15",
+    "responses>=0.26",
+    "xmltodict>=1.0",
+    "python-dotenv>=1.2",
 ]
 
 [tool.setuptools.dynamic]

--- a/uv.lock
+++ b/uv.lock
@@ -705,23 +705,23 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests" }]
+requires-dist = [{ name = "requests", specifier = ">=2.25.0" }]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "black", specifier = "==26.3.1" },
-    { name = "coverage" },
-    { name = "flake8" },
-    { name = "mypy" },
+    { name = "coverage", specifier = ">=7.15" },
+    { name = "flake8", specifier = ">=7.3" },
+    { name = "mypy", specifier = ">=2.3" },
     { name = "pdoc", specifier = "==14.5.1" },
-    { name = "pre-commit" },
+    { name = "pre-commit", specifier = ">=4.6" },
     { name = "pygments", specifier = "==2.20.0" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "python-dotenv" },
-    { name = "responses" },
-    { name = "types-requests" },
-    { name = "xmltodict" },
+    { name = "pytest", specifier = ">=9.1" },
+    { name = "pytest-cov", specifier = ">=7.1" },
+    { name = "python-dotenv", specifier = ">=1.2" },
+    { name = "responses", specifier = ">=0.26" },
+    { name = "types-requests", specifier = ">=2.33" },
+    { name = "xmltodict", specifier = ">=1.0" },
 ]
 docs = [
     { name = "pdoc", specifier = "==14.5.1" },
@@ -729,17 +729,17 @@ docs = [
 ]
 lint = [
     { name = "black", specifier = "==26.3.1" },
-    { name = "flake8" },
-    { name = "mypy" },
-    { name = "types-requests" },
+    { name = "flake8", specifier = ">=7.3" },
+    { name = "mypy", specifier = ">=2.3" },
+    { name = "types-requests", specifier = ">=2.33" },
 ]
 test = [
-    { name = "coverage" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "python-dotenv" },
-    { name = "responses" },
-    { name = "xmltodict" },
+    { name = "coverage", specifier = ">=7.15" },
+    { name = "pytest", specifier = ">=9.1" },
+    { name = "pytest-cov", specifier = ">=7.1" },
+    { name = "python-dotenv", specifier = ">=1.2" },
+    { name = "responses", specifier = ">=0.26" },
+    { name = "xmltodict", specifier = ">=1.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
CLAUDE.md still described the pre-#204 packaging: setup.py/setup.cfg,
requirements.txt/test-requirements.txt, ./setup.sh creating ./pyenv, the
mypy misc override in setup.cfg and a Python 3.9-3.12 support matrix.

- describe the PEP 621 pyproject.toml + uv workflow (uv sync, .venv,
  uv.lock, dependency groups, make build, uv run --python)
- point the mypy misc override and the flake8 config at their new homes
  (pyproject.toml, .flake8)
- update the supported Python versions to >= 3.10 (CI 3.10-3.14)
- drop the stale "CONTRIBUTING.md is outdated" note (it now documents uv)
  and the mypy python_version warning gotcha (mypy is clean again)
- add gotchas about keeping the black pin in sync between pyproject.toml
  and .pre-commit-config.yaml, and about not hand-editing uv.lock

Also add .github/dependabot.yml with weekly version updates for the uv,
github-actions and pre-commit ecosystems. Dev dependencies are grouped
into a single PR so runtime bumps of requests stay separate.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016TR7rjfSxGcUMNeDGc3xBH