### PR TITLE
Add dedicated error classes for OSM-side failures (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project follows [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Dedicated error classes for failures that are not caused by the request itself (see issue #194). Previously an HTTP 500 from the OSM API — like any other unmapped status — was raised as a plain `ApiError`, so telling "OpenStreetMap is having a bad day" apart from "my request was wrong" meant inspecting `ApiError.status` by hand:
+  - `ServerApiError` for any 5xx, with `InternalServerApiError` (500), `BadGatewayApiError` (502), `ServiceUnavailableApiError` (503) and `GatewayTimeoutApiError` (504) for the specific cases
+  - `RateLimitApiError` when the API refuses the request because a limit was exceeded (429 too many requests, 509 bandwidth limit exceeded)
+  - `RetriableApiError`, the common superclass of all of the above and of `TimeoutApiError`/`ConnectionApiError`, to catch every transient failure in one place:
+    ```python
+    try:
+        node = api.node_get(123)
+    except osmapi.RetriableApiError as e:
+        wait_and_try_again(e.retry_after)
+    ```
+  All of these are subclasses of `ApiError`, so existing `except osmapi.ApiError` clauses keep working unchanged
+- `ApiError.retry_after`, the number of seconds the API asked to wait before retrying (its `Retry-After` header, both the delay-seconds and the HTTP-date form are supported), or `None` if it did not send one
+
+### Changed
+- Requests that ran into a rate limit (HTTP 429 and 509) are now retried instead of raising immediately, like server errors already were. Such a call now takes longer before it eventually fails
+- The wait between two retries doubles after every attempt (5s, 10s, 20s, capped at 60s) instead of being a constant 5s, since these errors happen more often when the OSM servers are under load. The first retry still follows immediately. A `Retry-After` sent by the API takes precedence over this schedule
 
 ## [6.0.0] - 2026-07-27
 ### Changed

--- a/examples/error_handling.py
+++ b/examples/error_handling.py
@@ -36,6 +36,9 @@ def clear_screen():
 # - All osmapi excepctions are child classes of osmapi.OsmApiError
 # - Errors that result from the communication with the OSM server osmapi.ApiError
 # - There are a number of subclasses to differantiate the different errors
+# - Errors that are not caused by the request itself (the server failed, a rate
+#   limit was hit, the server could not be reached) are subclasses of
+#   osmapi.RetriableApiError and are worth trying again later
 # - catch more specific errors first, then use more general error classes
 
 # Upload data to OSM without a changeset
@@ -131,6 +134,15 @@ except osmapi.ConnectionApiError as e:
     # display error for user, try again?
 except osmapi.ElementNotFoundApiError as e:
     log.debug(f"Changeset not found: {str(e)}")
+    exit_code = 1
+except osmapi.RateLimitApiError as e:
+    # the API asks us to slow down, e.retry_after tells us for how long
+    log.debug(f"Rate limited, retry in {e.retry_after} seconds: {str(e)}")
+    exit_code = 1
+except osmapi.ServerApiError as e:
+    # osmapi already retried this a couple of times, the OSM servers are
+    # having a bad day - try again later
+    log.debug(f"The OSM server failed to handle the request: {str(e)}")
     exit_code = 1
 except osmapi.ApiError as e:
     log.debug(f"Error on the API side: {str(e)}")

--- a/osmapi/OsmApi.py
+++ b/osmapi/OsmApi.py
@@ -24,6 +24,32 @@ Find all information about changes of the different versions of this module
 `{"role": "", "ref":123, "type": "node"}`
 * All method names are in snake_case. The deprecated CamelCase versions
 (e.g. `NodeGet`) were removed in version 6.0.
+
+## Error handling:
+
+All errors raised by this module are subclasses of `OsmApi.OsmApiError`,
+those that come from a request to the API are subclasses of
+`OsmApi.ApiError`. Catch the specific error you want to handle first, and a
+more general one after it.
+
+Failures that are not caused by the request itself — the API failed
+(`OsmApi.ServerApiError`), refused because a limit was exceeded
+(`OsmApi.RateLimitApiError`), or could not be reached
+(`OsmApi.TimeoutApiError`, `OsmApi.ConnectionApiError`) — share the common
+superclass `OsmApi.RetriableApiError` and are worth trying again later:
+
+    #!python
+    try:
+        node = api.node_get(123)
+    except osmapi.RetriableApiError as e:
+        # e.retry_after is the delay the API asked for, if it sent one
+        wait_and_try_again(e.retry_after)
+    except osmapi.ElementNotFoundApiError:
+        ...
+
+osmapi already retries server errors and rate limits a number of times on
+its own (see `OsmApi.http.OsmApiSession.MAX_RETRY_LIMIT`), waiting longer
+after every attempt and respecting the `Retry-After` header of the response.
 """
 
 import re

--- a/osmapi/errors.py
+++ b/osmapi/errors.py
@@ -79,7 +79,13 @@ class ApiError(OsmApiError):
     Error class, is thrown when an API request fails
     """
 
-    def __init__(self, status: int, reason: str, payload: Any) -> None:
+    def __init__(
+        self,
+        status: int,
+        reason: str,
+        payload: Any,
+        retry_after: float | None = None,
+    ) -> None:
         self.status = status
         """HTTP error code"""
 
@@ -88,6 +94,17 @@ class ApiError(OsmApiError):
 
         self.payload = payload
         """Payload of API when this error occured"""
+
+        self.retry_after = retry_after
+        """
+        Number of seconds the server asked to wait before retrying, or `None`.
+
+        This is the `Retry-After` header of the response, which the API sends
+        with rate limits (HTTP 429) and when it is temporarily unavailable
+        (HTTP 503). Both the delay-seconds and the HTTP-date form of the
+        header are resolved to a number of seconds; a missing or unparseable
+        header results in `None`.
+        """
 
     @property
     def payload_str(self) -> str:
@@ -103,6 +120,88 @@ class ApiError(OsmApiError):
 
     def __str__(self) -> str:
         return f"Request failed: {self.status} - {self.reason} - {self.payload}"
+
+
+class RetriableApiError(ApiError):
+    """
+    Error that is worth trying again later.
+
+    Superclass of every error that does not indicate a problem with the
+    request itself: the server failed (`OsmApi.ServerApiError`), it refused
+    because of a rate limit (`OsmApi.RateLimitApiError`), or it could not be
+    reached at all (`OsmApi.TimeoutApiError`, `OsmApi.ConnectionApiError`).
+    Catch this to handle all transient failures in one place:
+
+        #!python
+        try:
+            api.node_get(123)
+        except osmapi.RetriableApiError as e:
+            wait_and_try_again(e.retry_after)
+
+    osmapi already retries some of these itself (see
+    `OsmApi.http.OsmApiSession.MAX_RETRY_LIMIT`) — an error of this class
+    reaching the caller means those retries were exhausted, or that the error
+    is one osmapi does not retry on its own. Timeouts and connection errors
+    are never retried automatically, as a request that never gets an answer
+    would otherwise block for several times the configured timeout.
+    """
+
+
+class ServerApiError(RetriableApiError):
+    """
+    Error when the API failed to handle the request (HTTP 5xx).
+
+    The fault is on the OpenStreetMap side rather than with the request, and
+    such errors are usually transient — they happen more often when the OSM
+    servers are under load. `OsmApi.InternalServerApiError`,
+    `OsmApi.BadGatewayApiError`, `OsmApi.ServiceUnavailableApiError` and
+    `OsmApi.GatewayTimeoutApiError` are the specific cases; any other 5xx
+    status is raised as `OsmApi.ServerApiError` itself.
+
+    Note that HTTP 509 (bandwidth limit exceeded) is _not_ part of this
+    group, even though it is numerically a 5xx: it is a quota, not a server
+    failure, and is raised as `OsmApi.RateLimitApiError`.
+    """
+
+
+class InternalServerApiError(ServerApiError):
+    """
+    Error when the API encountered an unexpected condition (HTTP 500)
+    """
+
+
+class BadGatewayApiError(ServerApiError):
+    """
+    Error when the API is unreachable behind its proxy (HTTP 502)
+    """
+
+
+class ServiceUnavailableApiError(ServerApiError):
+    """
+    Error when the API is temporarily unavailable (HTTP 503),
+    e.g. while the OpenStreetMap database is in maintenance or read-only mode
+    """
+
+
+class GatewayTimeoutApiError(ServerApiError):
+    """
+    Error when the API did not answer its proxy in time (HTTP 504)
+    """
+
+
+class RateLimitApiError(RetriableApiError):
+    """
+    Error when the API refused the request because a limit was exceeded:
+    too many requests (HTTP 429) or too much data downloaded
+    (HTTP 509, bandwidth limit exceeded).
+
+    Unlike `OsmApi.ServerApiError` this is not a failure of the API, so it is
+    not a subclass of it — despite HTTP 509 being a 5xx status. Use
+    `OsmApi.RetriableApiError` to catch both.
+
+    `retry_after` carries the number of seconds the API asked to wait, if it
+    sent a `Retry-After` header.
+    """
 
 
 class UnauthorizedApiError(ApiError):
@@ -182,13 +281,13 @@ class PreconditionFailedApiError(ApiError):
     """
 
 
-class TimeoutApiError(ApiError):
+class TimeoutApiError(RetriableApiError):
     """
     Error if the http request ran into a timeout
     """
 
 
-class ConnectionApiError(ApiError):
+class ConnectionApiError(RetriableApiError):
     """
     Error if there was a network error (e.g. DNS failure, refused connection)
     while connecting to the remote server.

--- a/osmapi/http.py
+++ b/osmapi/http.py
@@ -3,6 +3,7 @@ HTTP session management for the OpenStreetMap API.
 """
 
 import datetime
+import email.utils
 import itertools as it
 import logging
 import requests
@@ -13,10 +14,71 @@ from . import errors
 
 logger = logging.getLogger(__name__)
 
+ERROR_BY_STATUS: dict[int, type[errors.ApiError]] = {
+    401: errors.UnauthorizedApiError,
+    404: errors.ElementNotFoundApiError,
+    410: errors.ElementDeletedApiError,
+    429: errors.RateLimitApiError,
+    500: errors.InternalServerApiError,
+    502: errors.BadGatewayApiError,
+    503: errors.ServiceUnavailableApiError,
+    504: errors.GatewayTimeoutApiError,
+    509: errors.RateLimitApiError,
+}
+"""
+Error class raised for a given HTTP status code.
+
+Any other status >= 500 becomes a generic `OsmApi.ServerApiError`, anything
+else a plain `OsmApi.ApiError`. Note that 509 (bandwidth limit exceeded) is a
+rate limit rather than a server failure, hence it is not a `ServerApiError`.
+"""
+
+RETRY_ON = (errors.ServerApiError, errors.RateLimitApiError)
+"""
+Errors that make `OsmApiSession._http` try the request again.
+
+This is osmapi's own retry policy, which is narrower than
+`OsmApi.RetriableApiError`: a timeout or a connection error is worth
+retrying for a caller, but retrying it here would block for several times the
+configured timeout before reporting a server that is simply unreachable.
+"""
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """
+    Convert a `Retry-After` header into a number of seconds.
+
+    The header comes either as delay-seconds (`"120"`) or as an HTTP-date
+    (`"Wed, 21 Oct 2015 07:28:00 GMT"`), see RFC 9110. Returns `None` if the
+    header is missing or cannot be parsed, and never returns a negative delay
+    (a date in the past means "retry now").
+    """
+    if value is None:
+        return None
+    value = value.strip()
+    # RFC 9110 defines delay-seconds as digits only; parsing this with float()
+    # would also accept "inf" and "nan", which `time.sleep` chokes on
+    if value.isdigit():
+        return float(value)
+    try:
+        retry_at = email.utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return max((retry_at - now).total_seconds(), 0)
+
 
 class OsmApiSession:
     MAX_RETRY_LIMIT = 5
     """Maximum retries if a call to the remote API fails (default: 5)"""
+
+    RETRY_BASE_DELAY = 5
+    """Seconds to wait before the second attempt, doubling for each further one"""
+
+    MAX_RETRY_DELAY = 60
+    """Upper bound for the wait between two attempts, including `Retry-After`"""
 
     def __init__(
         self,
@@ -86,7 +148,13 @@ class OsmApiSession:
         If the requested element can not be found,
         `OsmApi.ElementNotFoundApiError` is raised.
 
-        If the response status code indicates an error,
+        If the API failed to handle the request (HTTP 5xx),
+        `OsmApi.ServerApiError` (or one of its subclasses) is raised.
+
+        If the API refused the request because a limit was exceeded,
+        `OsmApi.RateLimitApiError` is raised.
+
+        If the response status code indicates any other error,
         `OsmApi.ApiError` is raised.
         """
         logger.debug(f"{datetime.datetime.now():%Y-%m-%d %H:%M:%S} {method} {path}")
@@ -116,19 +184,19 @@ class OsmApiSession:
 
         if response.status_code != 200:
             payload = response.content.strip()
-            if response.status_code == 401:
-                raise errors.UnauthorizedApiError(
-                    response.status_code, response.reason, payload
+            error_class = ERROR_BY_STATUS.get(response.status_code)
+            if error_class is None:
+                error_class = (
+                    errors.ServerApiError
+                    if response.status_code >= 500
+                    else errors.ApiError
                 )
-            if response.status_code == 404:
-                raise errors.ElementNotFoundApiError(
-                    response.status_code, response.reason, payload
-                )
-            elif response.status_code == 410:
-                raise errors.ElementDeletedApiError(
-                    response.status_code, response.reason, payload
-                )
-            raise errors.ApiError(response.status_code, response.reason, payload)
+            raise error_class(
+                response.status_code,
+                response.reason,
+                payload,
+                retry_after=_parse_retry_after(response.headers.get("Retry-After")),
+            )
         if return_value and not response.content:
             raise errors.ResponseEmptyApiError(
                 response.status_code, response.reason, ""
@@ -152,11 +220,12 @@ class OsmApiSession:
                     cmd, path, auth, send, return_value=return_value, params=params
                 )
             except errors.ApiError as e:
-                if e.status >= 500:
+                if isinstance(e, RETRY_ON):
                     if i == self.MAX_RETRY_LIMIT:
                         raise
-                    if i != 1:
-                        self._sleep()
+                    delay = self._retry_delay(i, e.retry_after)
+                    if delay:
+                        self._sleep(delay)
                     self._session = self._get_http_session()
                 else:
                     logger.debug("ApiError Exception occured")
@@ -171,8 +240,9 @@ class OsmApiSession:
                     raise errors.MaximumRetryLimitReachedError(
                         f"Give up after {i} retries"
                     ) from e
-                if i != 1:
-                    self._sleep()
+                delay = self._retry_delay(i)
+                if delay:
+                    self._sleep(delay)
                 self._session = self._get_http_session()
 
     def _get_http_session(self) -> requests.Session:
@@ -188,8 +258,28 @@ class OsmApiSession:
         session.headers.update({"user-agent": self._created_by})
         return session
 
-    def _sleep(self) -> None:
-        time.sleep(5)
+    def _retry_delay(self, attempt: int, retry_after: float | None = None) -> float:
+        """
+        Seconds to wait before attempt number `attempt` + 1.
+
+        A `Retry-After` sent by the API wins over the schedule, but is capped
+        at `MAX_RETRY_DELAY` — if the API asks for a longer break than that,
+        the remaining attempts run into the same limit and the error is
+        reported to the caller, which can wait for `ApiError.retry_after` and
+        try again itself.
+
+        Without such a header the first retry follows immediately (a single
+        failed request is often just a hiccup), and every further one waits
+        twice as long as the previous, starting at `RETRY_BASE_DELAY`.
+        """
+        if retry_after is not None:
+            return min(retry_after, self.MAX_RETRY_DELAY)
+        if attempt <= 1:
+            return 0
+        return min(self.RETRY_BASE_DELAY * 2 ** (attempt - 2), self.MAX_RETRY_DELAY)
+
+    def _sleep(self, seconds: float = 5) -> None:
+        time.sleep(seconds)
 
     def _get(self, path: str, params: dict | None = None) -> bytes:
         return self._http("GET", path, False, None, params=params)

--- a/tests/changeset_test.py
+++ b/tests/changeset_test.py
@@ -959,7 +959,7 @@ def test_changeset_update_server_error(auth_api, add_response):
     with pytest.raises(osmapi.ApiError) as execinfo:
         auth_api.changeset_update({"test": "foobar"})
 
-    assert type(execinfo.value) is osmapi.ApiError
+    assert type(execinfo.value) is osmapi.InternalServerApiError
     assert execinfo.value.status == 500
 
 
@@ -1103,7 +1103,7 @@ def test_changeset_close_server_error(auth_api, add_response):
     with pytest.raises(osmapi.ApiError) as execinfo:
         auth_api.changeset_close()
 
-    assert type(execinfo.value) is osmapi.ApiError
+    assert type(execinfo.value) is osmapi.InternalServerApiError
     assert execinfo.value.status == 500
     # the changeset is still considered open, since closing it failed
     assert auth_api._current_changeset_id == 1414

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,12 +164,19 @@ def assert_request_xml(xml_dict):
     return _assert_request_xml
 
 
-def make_http_response(status=200, content="test response", reason="test reason"):
-    """Build a minimal stand-in for a `requests` response."""
+def make_http_response(
+    status=200, content="test response", reason="test reason", headers=None
+):
+    """Build a minimal stand-in for a `requests` response.
+
+    `headers` has to be a real dict rather than a `Mock` attribute, otherwise
+    `response.headers.get(...)` answers with a `Mock` instead of `None`.
+    """
     response = mock.Mock()
     response.status_code = status
     response.reason = reason
     response.content = content
+    response.headers = headers if headers is not None else {}
     return response
 
 
@@ -200,6 +207,7 @@ def mock_api():
         auth=True,
         responses=None,
         side_effect=None,
+        headers=None,
     ):
         session = mock.Mock()
         session.close = mock.Mock()
@@ -211,7 +219,7 @@ def mock_api():
             session.request = mock.Mock(side_effect=list(responses))
         else:
             session.request = mock.Mock(
-                return_value=make_http_response(status, content, reason)
+                return_value=make_http_response(status, content, reason, headers)
             )
 
         api = osmapi.OsmApi(api=API_BASE, session=session)

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -51,6 +51,13 @@ def test_api_error_str():
         osmapi.TimeoutApiError,
         osmapi.ConnectionApiError,
         osmapi.ResponseEmptyApiError,
+        osmapi.RetriableApiError,
+        osmapi.ServerApiError,
+        osmapi.InternalServerApiError,
+        osmapi.BadGatewayApiError,
+        osmapi.ServiceUnavailableApiError,
+        osmapi.GatewayTimeoutApiError,
+        osmapi.RateLimitApiError,
     ],
 )
 def test_api_errors_are_catchable_as_api_error(error_class):
@@ -60,6 +67,80 @@ def test_api_errors_are_catchable_as_api_error(error_class):
     assert isinstance(error, osmapi.ApiError)
     assert isinstance(error, osmapi.OsmApiError)
     assert error.payload_str == "payload"
+
+
+##################################################
+# Retriable errors (server failures, rate limits)#
+##################################################
+
+
+@pytest.mark.parametrize(
+    "error_class",
+    [
+        osmapi.ServerApiError,
+        osmapi.InternalServerApiError,
+        osmapi.BadGatewayApiError,
+        osmapi.ServiceUnavailableApiError,
+        osmapi.GatewayTimeoutApiError,
+        osmapi.RateLimitApiError,
+        osmapi.TimeoutApiError,
+        osmapi.ConnectionApiError,
+    ],
+)
+def test_transient_errors_are_catchable_as_retriable(error_class):
+    """One `except` clause covers every failure that is worth trying again."""
+    error = error_class(503, "Service Unavailable", b"try later")
+
+    assert isinstance(error, osmapi.RetriableApiError)
+
+
+@pytest.mark.parametrize(
+    "error_class",
+    [
+        osmapi.InternalServerApiError,
+        osmapi.BadGatewayApiError,
+        osmapi.ServiceUnavailableApiError,
+        osmapi.GatewayTimeoutApiError,
+    ],
+)
+def test_server_errors_are_catchable_as_server_error(error_class):
+    error = error_class(500, "Internal Server Error", b"boom")
+
+    assert isinstance(error, osmapi.ServerApiError)
+
+
+def test_rate_limit_error_is_not_a_server_error():
+    """A quota is not a failure of the API, even though HTTP 509 is a 5xx."""
+    error = osmapi.RateLimitApiError(509, "Bandwidth Limit Exceeded", b"too much")
+
+    assert not isinstance(error, osmapi.ServerApiError)
+    assert isinstance(error, osmapi.RetriableApiError)
+
+
+def test_errors_that_are_not_retriable():
+    """A request the API rejected is not retried, retrying would fail again."""
+    for error_class in (
+        osmapi.UnauthorizedApiError,
+        osmapi.ElementNotFoundApiError,
+        osmapi.ElementDeletedApiError,
+        osmapi.VersionMismatchApiError,
+        osmapi.PreconditionFailedApiError,
+    ):
+        assert not isinstance(
+            error_class(400, "reason", b"payload"), osmapi.RetriableApiError
+        )
+
+
+def test_retry_after_defaults_to_none():
+    error = osmapi.ApiError(500, "Internal Server Error", b"boom")
+
+    assert error.retry_after is None
+
+
+def test_retry_after_is_kept():
+    error = osmapi.RateLimitApiError(429, "Too Many Requests", b"slow down", 120)
+
+    assert error.retry_after == 120
 
 
 ##################################################

--- a/tests/http_test.py
+++ b/tests/http_test.py
@@ -1,5 +1,7 @@
 """Tests for the HTTP layer: status-code mapping and the retry loop."""
 
+import datetime
+from email.utils import format_datetime
 from unittest import mock
 
 import osmapi
@@ -110,7 +112,12 @@ def test_http_request_auth_with_authorization_header():
         (401, osmapi.UnauthorizedApiError),
         (404, osmapi.ElementNotFoundApiError),
         (410, osmapi.ElementDeletedApiError),
-        (500, osmapi.ApiError),
+        (429, osmapi.RateLimitApiError),
+        (500, osmapi.InternalServerApiError),
+        (502, osmapi.BadGatewayApiError),
+        (503, osmapi.ServiceUnavailableApiError),
+        (504, osmapi.GatewayTimeoutApiError),
+        (509, osmapi.RateLimitApiError),
     ],
 )
 def test_http_request_error_status_mapping(mock_api, status, expected):
@@ -119,9 +126,96 @@ def test_http_request_error_status_mapping(mock_api, status, expected):
     with pytest.raises(expected) as execinfo:
         api._session._http_request("GET", f"/api/0.6/test{status}", False, None)
 
+    assert type(execinfo.value) is expected
     assert execinfo.value.status == status
     assert execinfo.value.reason == "test reason"
     assert execinfo.value.payload == "test response"
+
+
+def test_http_request_unmapped_server_error(mock_api):
+    """Any other 5xx is still recognisable as a failure on the OSM side."""
+    api, _ = mock_api(status=507)
+
+    with pytest.raises(osmapi.ServerApiError) as execinfo:
+        api._session._http_request("GET", "/api/0.6/test", False, None)
+
+    assert type(execinfo.value) is osmapi.ServerApiError
+    assert execinfo.value.status == 507
+
+
+def test_http_request_unmapped_client_error(mock_api):
+    """A 4xx without its own class stays a plain, non-retriable ApiError."""
+    api, _ = mock_api(status=405)
+
+    with pytest.raises(osmapi.ApiError) as execinfo:
+        api._session._http_request("GET", "/api/0.6/test", False, None)
+
+    assert type(execinfo.value) is osmapi.ApiError
+    assert not isinstance(execinfo.value, osmapi.RetriableApiError)
+
+
+##################################################
+# The Retry-After header                         #
+##################################################
+
+
+def test_http_request_retry_after_seconds(mock_api):
+    api, _ = mock_api(status=429, headers={"Retry-After": "120"})
+
+    with pytest.raises(osmapi.RateLimitApiError) as execinfo:
+        api._session._http_request("GET", "/api/0.6/test", False, None)
+
+    assert execinfo.value.retry_after == 120
+
+
+def test_http_request_retry_after_http_date(mock_api):
+    """The other form RFC 9110 allows: an absolute date instead of a delay."""
+    retry_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        seconds=90
+    )
+    api, _ = mock_api(
+        status=503, headers={"Retry-After": format_datetime(retry_at, usegmt=True)}
+    )
+
+    with pytest.raises(osmapi.ServiceUnavailableApiError) as execinfo:
+        api._session._http_request("GET", "/api/0.6/test", False, None)
+
+    # the header has a resolution of one second, so allow for the rounding
+    assert 88 <= execinfo.value.retry_after <= 90
+
+
+def test_http_request_retry_after_in_the_past(mock_api):
+    """A date that has already passed means "retry now", not a negative wait."""
+    retry_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=90
+    )
+    api, _ = mock_api(
+        status=503, headers={"Retry-After": format_datetime(retry_at, usegmt=True)}
+    )
+
+    with pytest.raises(osmapi.ServiceUnavailableApiError) as execinfo:
+        api._session._http_request("GET", "/api/0.6/test", False, None)
+
+    assert execinfo.value.retry_after == 0
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        {},
+        {"Retry-After": "later please"},
+        # float() would accept these, and time.sleep() would then fail
+        {"Retry-After": "inf"},
+        {"Retry-After": "nan"},
+    ],
+)
+def test_http_request_without_usable_retry_after(mock_api, header):
+    api, _ = mock_api(status=503, headers=header)
+
+    with pytest.raises(osmapi.ServiceUnavailableApiError) as execinfo:
+        api._session._http_request("GET", "/api/0.6/test", False, None)
+
+    assert execinfo.value.retry_after is None
 
 
 def test_http_request_empty_response(mock_api):
@@ -210,6 +304,77 @@ def test_http_does_not_retry_client_error(mock_api):
     api, session = mock_api(status=404)
 
     with pytest.raises(osmapi.ElementNotFoundApiError):
+        api._session._http("GET", "/api/0.6/test", False, None)
+
+    assert session.request.call_count == 1
+    assert api._session._sleep.call_count == 0
+
+
+def test_http_waits_longer_after_every_attempt(mock_api):
+    """Retrying an overloaded server immediately only adds to the load."""
+    api, session = mock_api(status=500)
+
+    with pytest.raises(osmapi.InternalServerApiError):
+        api._session._http("GET", "/api/0.6/test", False, None)
+
+    assert session.request.call_count == 5
+    # the first retry is immediate, the waits then double
+    assert api._session._sleep.call_args_list == [
+        mock.call(5),
+        mock.call(10),
+        mock.call(20),
+    ]
+
+
+def test_http_retries_rate_limit(mock_api):
+    """A rate limit used to raise right away, now it is waited out."""
+    api, session = mock_api(
+        responses=[
+            make_http_response(status=429, headers={"Retry-After": "30"}),
+            make_http_response(status=200, content="ok"),
+        ]
+    )
+
+    result = api._session._http("GET", "/api/0.6/test", False, None)
+
+    assert result == "ok"
+    assert session.request.call_count == 2
+    # even the first retry waits when the API asked us to
+    api._session._sleep.assert_called_once_with(30)
+
+
+def test_http_gives_up_after_max_retries_on_rate_limit(mock_api):
+    api, session = mock_api(status=429)
+
+    with pytest.raises(osmapi.RateLimitApiError) as execinfo:
+        api._session._http("GET", "/api/0.6/test", False, None)
+
+    assert execinfo.value.status == 429
+    assert session.request.call_count == api._session.MAX_RETRY_LIMIT
+
+
+def test_http_caps_the_requested_delay(mock_api):
+    """A break of an hour is the caller's decision to make, not ours."""
+    api, _ = mock_api(status=503, headers={"Retry-After": "3600"})
+
+    with pytest.raises(osmapi.ServiceUnavailableApiError) as execinfo:
+        api._session._http("GET", "/api/0.6/test", False, None)
+
+    assert api._session._sleep.call_args_list == [mock.call(60)] * 4
+    # the caller can still wait out the full delay the API asked for
+    assert execinfo.value.retry_after == 3600
+
+
+@pytest.mark.parametrize(
+    "error",
+    [requests.exceptions.Timeout(), requests.exceptions.ConnectionError("boom")],
+    ids=["timeout", "connection"],
+)
+def test_http_does_not_retry_unreachable_server(mock_api, error):
+    """Retrying a timeout would block for a multiple of the timeout itself."""
+    api, session = mock_api(side_effect=error)
+
+    with pytest.raises(osmapi.RetriableApiError):
         api._session._http("GET", "/api/0.6/test", False, None)
 
     assert session.request.call_count == 1


### PR DESCRIPTION
An HTTP 500 from the OSM API used to be raised as a plain ApiError, the
same class as any other unmapped status, so telling a transient failure of
the API apart from a bad request meant inspecting ApiError.status by hand.

Add a group of errors below ApiError for the failures that are not caused
by the request itself:

- ServerApiError for any 5xx, with InternalServerApiError (500),
  BadGatewayApiError (502), ServiceUnavailableApiError (503) and
  GatewayTimeoutApiError (504) for the specific cases
- RateLimitApiError for 429 and 509, which is not a ServerApiError since a
  quota is not a failure of the API, despite 509 being a 5xx status
- RetriableApiError as the common superclass of both, and of the
  re-parented TimeoutApiError/ConnectionApiError, so every transient
  failure can be caught in one place

All of them are subclasses of ApiError, so existing except clauses keep
working.

The Retry-After header of the response is now parsed (both the
delay-seconds and the HTTP-date form) and exposed as ApiError.retry_after.
The retry loop honours it, retries rate limits instead of raising right
away, and waits longer after every attempt (5s, 10s, 20s, capped at 60s)
rather than a constant 5s, since these errors are more likely when the OSM
servers are under load.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Db565XXmJmRm7C18L2K2Tw