### PR TITLE
Build request XML with ElementTree instead of string concatenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project follows [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Request bodies are now assembled with `xml.etree.ElementTree` instead of by concatenating strings, so escaping is handled by the standard library (see issue #56). The generated XML is unchanged apart from formatting
+
+### Fixed
+- Fix tag values and member roles containing a newline, a tab or a carriage return being silently corrupted on write (`node_update`, `way_create`, `relation_delete`, `changeset_create`, `changeset_upload`, …). Those characters were written literally into an XML attribute, where the parser on the other end normalizes them to a space, so `{"note": "first\nsecond"}` arrived at the API as `"first second"`. They are now written as character references and round-trip unchanged. Member `type` was not escaped at all (see issue #216)
 
 ## [6.0.0] - 2026-07-27
 ### Changed

--- a/osmapi/xmlbuilder.py
+++ b/osmapi/xmlbuilder.py
@@ -1,72 +1,82 @@
+"""
+XML generation for requests to the OpenStreetMap API.
+
+The documents are assembled as `xml.etree.ElementTree` elements and
+serialized by `ElementTree.tostring`, so escaping is the standard library's
+job. Building them by hand used to miss everything but `& " < >`, which
+silently corrupted any tag value containing a newline or a tab: XML
+normalizes those to a space in an attribute value unless they are written as
+character references (see issue #216).
+"""
+
+import xml.etree.ElementTree as ET
 from typing import Any, TYPE_CHECKING
 from xml.dom.minidom import Element
 
 if TYPE_CHECKING:
     from .OsmApi import OsmApi
 
+_XML_PROLOG = '<?xml version="1.0" encoding="UTF-8"?>\n'
 
-def _xml_build(  # noqa: C901
+
+def _xml_build(
     element_type: str,
     element_data: dict[str, Any],
     with_headers: bool = True,
     *,
     data: "OsmApi",
 ) -> bytes:
-    xml = ""
+    """
+    Returns the XML document for a write of `element_data`.
+
+    With `with_headers` the element is wrapped in an `<osm>` envelope and
+    prefixed with the XML prolog, otherwise only the element itself is
+    returned — that is how `OsmApi._add_changeset_data` collects the parts of
+    an `<osmChange>` upload.
+    """
+    root = _xml_element(element_type, element_data, data=data)
+    prolog = ""
     if with_headers:
-        xml += '<?xml version="1.0" encoding="UTF-8"?>\n'
-        xml += '<osm version="0.6" generator="'
-        xml += data._created_by + '">'
-        xml += "\n"
+        osm = ET.Element("osm", {"version": "0.6", "generator": data._created_by})
+        osm.append(root)
+        root = osm
+        prolog = _XML_PROLOG
 
-    # <element attr="val">
-    xml += "  <" + element_type
-    if "id" in element_data:
-        xml += ' id="' + str(element_data["id"]) + '"'
-    if "lat" in element_data:
-        xml += ' lat="' + str(element_data["lat"]) + '"'
-    if "lon" in element_data:
-        xml += ' lon="' + str(element_data["lon"]) + '"'
-    if "version" in element_data:
-        xml += ' version="' + str(element_data["version"]) + '"'
-    visible_str = str(element_data.get("visible", True)).lower()
-    xml += ' visible="' + visible_str + '"'
-    if element_type in ["node", "way", "relation"]:
-        xml += ' changeset="' + str(data._current_changeset_id) + '"'
-    xml += ">\n"
+    ET.indent(root, space="  ")
+    return f"{prolog}{ET.tostring(root, encoding='unicode')}\n".encode("utf-8")
 
-    # <tag... />
+
+def _xml_element(
+    element_type: str, element_data: dict[str, Any], *, data: "OsmApi"
+) -> ET.Element:
+    """
+    Returns `element_data` as an element of type `element_type`.
+    """
+    attributes: dict[str, str] = {
+        key: str(element_data[key])
+        for key in ("id", "lat", "lon", "version")
+        if key in element_data
+    }
+    attributes["visible"] = str(element_data.get("visible", True)).lower()
+    if element_type in ("node", "way", "relation"):
+        attributes["changeset"] = str(data._current_changeset_id)
+
+    element = ET.Element(element_type, attributes)
     for k, v in element_data.get("tag", {}).items():
-        xml += '    <tag k="' + _xml_encode(k)
-        xml += '" v="' + _xml_encode(v) + '"/>\n'
-
-    # <member... />
+        ET.SubElement(element, "tag", {"k": k, "v": v})
     for member in element_data.get("member", []):
-        xml += '    <member type="' + member["type"]
-        xml += '" ref="' + str(member["ref"])
-        xml += '" role="' + _xml_encode(member["role"])
-        xml += '"/>\n'
-
-    # <nd... />
+        ET.SubElement(
+            element,
+            "member",
+            {
+                "type": member["type"],
+                "ref": str(member["ref"]),
+                "role": member["role"],
+            },
+        )
     for ref in element_data.get("nd", []):
-        xml += '    <nd ref="' + str(ref) + '"/>\n'
-
-    # </element>
-    xml += "  </" + element_type + ">\n"
-
-    if with_headers:
-        xml += "</osm>\n"
-
-    return xml.encode("utf8")
-
-
-def _xml_encode(text: str) -> str:
-    return (
-        text.replace("&", "&amp;")
-        .replace('"', "&quot;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-    )
+        ET.SubElement(element, "nd", {"ref": str(ref)})
+    return element
 
 
 def _get_xml_value(dom_element: Element, tag: str) -> str | None:

--- a/tests/xmlbuilder_test.py
+++ b/tests/xmlbuilder_test.py
@@ -1,0 +1,116 @@
+"""Tests for the XML generated for write requests."""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+import osmapi
+from osmapi import xmlbuilder
+
+from .conftest import API_BASE, OPEN_CHANGESET_ID
+
+
+@pytest.fixture
+def build(changeset_api):
+    """Builds the XML for an element write and parses it back."""
+
+    def _build(element_type, element_data, with_headers=True):
+        xml = xmlbuilder._xml_build(
+            element_type, element_data, with_headers, data=changeset_api
+        )
+        assert isinstance(xml, bytes)
+        return xml, ET.fromstring(xml)
+
+    return _build
+
+
+def test_xml_build_wraps_the_element_in_an_osm_envelope(build):
+    xml, root = build("node", {"id": 1, "lat": 47.1, "lon": 8.5, "version": 3})
+
+    assert xml.startswith(b'<?xml version="1.0" encoding="UTF-8"?>')
+    assert root.tag == "osm"
+    assert root.attrib == {
+        "version": "0.6",
+        "generator": f"osmapi/{osmapi.__version__}",
+    }
+    assert list(root[0].attrib) == [
+        "id",
+        "lat",
+        "lon",
+        "version",
+        "visible",
+        "changeset",
+    ]
+    assert root[0].attrib["changeset"] == str(OPEN_CHANGESET_ID)
+
+
+def test_xml_build_without_headers_returns_the_bare_element(build):
+    xml, element = build("way", {"id": 2, "nd": [11, 12]}, with_headers=False)
+
+    assert not xml.startswith(b"<?xml")
+    assert element.tag == "way"
+    assert [nd.attrib["ref"] for nd in element] == ["11", "12"]
+
+
+def test_xml_build_defaults_visible_to_true(build):
+    _, root = build("node", {"id": 1})
+    assert root[0].attrib["visible"] == "true"
+
+    _, root = build("node", {"id": 1, "visible": False})
+    assert root[0].attrib["visible"] == "false"
+
+
+def test_xml_build_only_sets_changeset_on_elements(build):
+    """A `<changeset>` is not itself part of a changeset."""
+    _, root = build("changeset", {"tag": {"comment": "hello"}})
+
+    assert "changeset" not in root[0].attrib
+
+
+def test_xml_build_escapes_markup(build):
+    value = 'a & b <c> "d"'
+    _, root = build("node", {"id": 1, "tag": {"key": value}})
+
+    assert root[0][0].attrib == {"k": "key", "v": value}
+
+
+def test_xml_build_preserves_whitespace_in_values(build):
+    """Newlines and tabs survive the round trip (issue #216).
+
+    An XML parser normalizes literal newlines and tabs in an attribute value
+    to spaces, so they have to be written as character references. Escaping
+    only `& " < >` by hand silently corrupted such values on their way to the
+    API.
+    """
+    tags = {"note": "line one\nline two", "ref": "A\tB", "cr": "a\rb"}
+    xml, root = build("node", {"id": 1, "tag": tags})
+
+    assert b"&#10;" in xml
+    assert {tag.attrib["k"]: tag.attrib["v"] for tag in root[0]} == tags
+
+
+def test_xml_build_escapes_member_attributes(build):
+    member = {"type": "way", "ref": 9, "role": 'a"b\nc'}
+    _, root = build("relation", {"id": 1, "member": [member]})
+
+    assert root[0][0].attrib == {"type": "way", "ref": "9", "role": 'a"b\nc'}
+
+
+def test_xml_build_handles_unicode(build):
+    xml, root = build("node", {"id": 1, "tag": {"name": "Zürich 東京"}})
+
+    assert "Zürich 東京".encode("utf-8") in xml
+    assert root[0][0].attrib["v"] == "Zürich 東京"
+
+
+def test_node_update_sends_whitespace_in_tags_unharmed(changeset_api, add_response):
+    """The same round trip, over the wire this time."""
+    resp = add_response("PUT", "/node/876", body="7")
+
+    changeset_api.node_update(
+        {"id": 876, "lat": 47.1, "lon": 8.5, "tag": {"note": "first\nsecond"}}
+    )
+
+    assert resp.calls[0].request.url == f"{API_BASE}/api/0.6/node/876"
+    sent = ET.fromstring(resp.calls[0].request.body)
+    assert sent[0][0].attrib == {"k": "note", "v": "first\nsecond"}


### PR DESCRIPTION
Closes #216, addresses the `_XmlBuild` part of #56.

## The bug

`_xml_build` assembled request bodies by concatenating strings, and `_xml_encode` escaped only `&`, `"`, `<` and `>`. Anything else went into the XML attribute verbatim — including newlines, tabs and carriage returns, which [XML attribute-value normalization](https://www.w3.org/TR/xml/#AVNormalize) turns into a space at the other end.

```python
api.node_update({"id": 1, "tag": {"note": "line one\nline two", "ref": "A\tB"}})
```

produced `v="line one⏎line two"`, which the API reads back as `'line one line two'`. The request succeeds, no error is raised, the data is just quietly wrong. Multi-line values are common enough in OSM (`description`, `note`, `fixme`, `opening_hours`, `addr:*`) for this to matter.

Every write path goes through `_xml_build`: the node/way/relation create/update/delete methods, `changeset_create`/`changeset_update` (a multi-line changeset `comment` hits it too) and `changeset_upload`. Relation member `role` had the same problem, and member `type` was interpolated with no escaping at all, so a `"` in it produced malformed XML rather than an error.

## The fix

Documents are now assembled as `ET.Element`/`ET.SubElement` and serialized with `ET.tostring`, so escaping is the standard library's job and can't be forgotten for an individual attribute:

```xml
<tag k="note" v="line one&#10;line two" />
<tag k="ref" v="A&#09;B" />
```

which round-trips back to `'line one\nline two'` and `'A\tB'`. `_xml_encode` is gone, and the attribute assembly moved into a small `_xml_element` helper, which let `_xml_build` drop its `# noqa: C901`.

## What is deliberately unchanged

The wire format, apart from formatting. Same `<?xml version="1.0" encoding="UTF-8"?>` prolog (written directly rather than letting ElementTree emit its single-quoted variant), same attribute order (`id`, `lat`, `lon`, `version`, `visible`, `changeset`), same two-space indentation via `ET.indent`, and `with_headers=False` still returns the bare element that `_add_changeset_data` concatenates into an `<osmChange>` upload. The only cosmetic difference is ElementTree's `<tag ... />` self-closing style.

## Tests

The 199 existing tests pass unmodified — that is the behaviour-preservation evidence, since every request-body assertion in the suite compares parsed XML via xmltodict rather than raw strings.

New `tests/xmlbuilder_test.py` adds 9 tests: envelope and prolog, bare-element mode, the `visible` default, `changeset` not being set on a `<changeset>`, markup escaping, whitespace preservation, member attribute escaping, unicode, and one end-to-end test through `node_update` asserting the value survives on the wire.

I checked they earn their keep by running them against the old builder: exactly the three that assert the fix fail (`preserves_whitespace_in_values`, `escapes_member_attributes`, `node_update_sends_whitespace_in_tags_unharmed`), while the six structural ones pass.

`./test.sh` is green, 100% line coverage on `xmlbuilder.py`.

## Note on #215

This was originally committed on the branch behind #215 and has been moved here, so the two can be reviewed and merged independently — #215 is now back to just the parsing refactor. Both touch `osmapi/xmlbuilder.py` and `CHANGELOG.md`, so whichever merges second will need a small conflict resolution; #215 changes `_get_xml_value` (minidom → ElementTree) while this PR changes `_xml_build`. Happy to rebase whichever you'd rather merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Bt4TJAjNb4yCV9qhcF9HT

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bt4TJAjNb4yCV9qhcF9HT)_