### PR TITLE
Add changeset_comments_search to search changeset comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project follows [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- New method `changeset_comments_search` to search the comments of *all* changesets by author (`userid`/`username`) and by creation time (`created_after`/`created_before`), with an optional `limit` (see issue #220). It wraps `GET /api/0.6/changeset_comments`, which OpenStreetMap added in February 2025
+
 ### Changed
 - Request bodies are now assembled with `xml.etree.ElementTree` instead of by concatenating strings, so escaping is handled by the standard library (see issue #56). The generated XML is unchanged apart from formatting
 

--- a/osmapi/changeset.py
+++ b/osmapi/changeset.py
@@ -318,6 +318,76 @@ class ChangesetMixin:
             result[tmp_cs["id"]] = tmp_cs
         return result
 
+    def changeset_comments_search(
+        self: "OsmApi",
+        userid: int | None = None,
+        username: str | None = None,
+        created_after: str | None = None,
+        created_before: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Returns a list of changeset comments matching all criteria, most
+        recent first.
+
+        Unlike `OsmApi.OsmApi.changeset_get` with `include_discussion=True`,
+        which returns the discussion of a single changeset, this searches the
+        comments of *all* changesets.
+
+        All parameters are optional; without any of them the most recent
+        comments are returned.
+
+        `userid` (the numeric id) and `username` (the display name) restrict
+        the result to the comments written by that user.
+
+        `created_after` and `created_before` restrict the result to the
+        comments created in that time period. Both are strings, e.g.
+        `2025-02-01T00:00:00Z`. The API only supports an upper bound together
+        with a lower one, so `created_after` defaults to the epoch if only
+        `created_before` is given.
+
+        `limit` is the maximum number of comments to return; the API applies
+        its own default and maximum if it is not given.
+
+        Each comment is a dict:
+
+            #!python
+            {
+                'id': id of the comment,
+                'date': datetime of the comment,
+                'visible': True if the comment has not been hidden,
+                'uid': id of the author,
+                'user': display name of the author,
+                'text': text of the comment,
+            }
+
+        `uid` and `user` are omitted for authors whose data is not public.
+
+        If the user is unknown, or `limit` is outside of the range accepted by
+        the API, `OsmApi.ApiError` is raised.
+        """
+        uri = "/api/0.6/changeset_comments"
+        params: dict[str, Any] = {}
+        if userid:
+            params["user"] = userid
+        if username:
+            params["display_name"] = username
+        if created_after:
+            params["from"] = created_after
+        if created_before:
+            if not created_after:
+                params["from"] = "1970-01-01T00:00:00Z"
+            params["to"] = created_before
+        if limit is not None:
+            params["limit"] = limit
+
+        data = self._session._get(uri, params=params)
+        comments = cast(
+            list[Element],
+            dom.OsmResponseToDom(data, tag="comment", allow_empty=True),
+        )
+        return [dom.dom_parse_comment(comment) for comment in comments]
+
     def changeset_comment(
         self: "OsmApi", changeset_id: int, comment: str
     ) -> dict[str, Any]:

--- a/osmapi/dom.py
+++ b/osmapi/dom.py
@@ -85,6 +85,15 @@ def dom_parse_changeset(
     return result
 
 
+def dom_parse_comment(dom_element: Element) -> dict[str, Any]:
+    """
+    Returns CommentData for a changeset comment.
+    """
+    result = _dom_get_attributes(dom_element)
+    result["text"] = xmlbuilder._get_xml_value(dom_element, "text")
+    return result
+
+
 def dom_parse_note(dom_element: Element) -> dict[str, Any]:
     """
     Returns NoteData for the note.
@@ -167,9 +176,7 @@ def _dom_get_discussion(dom_element: Element) -> list[dict[str, Any]]:
     try:
         discussion = dom_element.getElementsByTagName("discussion")[0]
         for t in discussion.getElementsByTagName("comment"):
-            comment = _dom_get_attributes(t)
-            comment["text"] = xmlbuilder._get_xml_value(t, "text")
-            result.append(comment)
+            result.append(dom_parse_comment(t))
     except IndexError:
         pass
     return result

--- a/tests/changeset_test.py
+++ b/tests/changeset_test.py
@@ -927,6 +927,144 @@ def test_changesets_get_all_filters(api, add_response):
 
 
 ##################################################
+# changeset_comments_search                      #
+##################################################
+
+
+def test_changeset_comments_search(api, add_response):
+    resp = add_response(GET, "/changeset_comments")
+
+    result = api.changeset_comments_search()
+
+    assert resp.calls[0].request.url == (
+        "http://api06.dev.openstreetmap.org/api/0.6/changeset_comments"
+    )
+    assert result == [
+        {
+            "id": 3011,
+            "date": datetime.datetime(2025, 2, 14, 9, 12, 33),
+            "visible": True,
+            "uid": 1841,
+            "user": "metaodi",
+            "text": "Thanks for the fix!",
+        },
+        {
+            "id": 2984,
+            "date": datetime.datetime(2025, 2, 13, 17, 4, 10),
+            "visible": True,
+            "uid": 1841,
+            "user": "metaodi",
+            "text": "Did you verify those street names?",
+        },
+        {
+            # an author whose data is not public has no uid/user
+            "id": 2971,
+            "date": datetime.datetime(2025, 2, 12, 8, 45, 59),
+            "visible": True,
+            "text": "Comment of an author without public data",
+        },
+    ]
+
+
+def test_changeset_comments_search_by_userid(api, add_response):
+    resp = add_response(
+        GET, "/changeset_comments", filename="test_changeset_comments_search.xml"
+    )
+
+    api.changeset_comments_search(userid=1841)
+
+    assert resp.calls[0].request.params == {"user": "1841"}
+
+
+def test_changeset_comments_search_by_username(api, add_response):
+    resp = add_response(
+        GET, "/changeset_comments", filename="test_changeset_comments_search.xml"
+    )
+
+    api.changeset_comments_search(username="metaodi")
+
+    assert resp.calls[0].request.params == {"display_name": "metaodi"}
+
+
+def test_changeset_comments_search_created_after(api, add_response):
+    resp = add_response(
+        GET, "/changeset_comments", filename="test_changeset_comments_search.xml"
+    )
+
+    api.changeset_comments_search(created_after="2025-02-01T00:00:00Z")
+
+    assert resp.calls[0].request.params == {"from": "2025-02-01T00:00:00Z"}
+
+
+def test_changeset_comments_search_created_before(api, add_response):
+    """The API ignores an upper bound without a lower one, so one is added."""
+    resp = add_response(
+        GET, "/changeset_comments", filename="test_changeset_comments_search.xml"
+    )
+
+    api.changeset_comments_search(created_before="2025-03-01T00:00:00Z")
+
+    assert resp.calls[0].request.params == {
+        "from": "1970-01-01T00:00:00Z",
+        "to": "2025-03-01T00:00:00Z",
+    }
+
+
+def test_changeset_comments_search_time_range(api, add_response):
+    resp = add_response(
+        GET, "/changeset_comments", filename="test_changeset_comments_search.xml"
+    )
+
+    api.changeset_comments_search(
+        created_after="2025-02-01T00:00:00Z",
+        created_before="2025-03-01T00:00:00Z",
+    )
+
+    assert resp.calls[0].request.params == {
+        "from": "2025-02-01T00:00:00Z",
+        "to": "2025-03-01T00:00:00Z",
+    }
+
+
+def test_changeset_comments_search_all_params(api, add_response):
+    resp = add_response(
+        GET, "/changeset_comments", filename="test_changeset_comments_search.xml"
+    )
+
+    api.changeset_comments_search(
+        userid=1841,
+        username="metaodi",
+        created_after="2025-02-01T00:00:00Z",
+        created_before="2025-03-01T00:00:00Z",
+        limit=10,
+    )
+
+    assert resp.calls[0].request.params == {
+        "user": "1841",
+        "display_name": "metaodi",
+        "from": "2025-02-01T00:00:00Z",
+        "to": "2025-03-01T00:00:00Z",
+        "limit": "10",
+    }
+
+
+def test_changeset_comments_search_empty_result(api, add_response):
+    add_response(GET, "/changeset_comments")
+
+    assert api.changeset_comments_search(username="metaodi") == []
+
+
+def test_changeset_comments_search_unknown_user(api, add_response):
+    add_response(GET, "/changeset_comments", status=400)
+
+    with pytest.raises(osmapi.ApiError) as execinfo:
+        api.changeset_comments_search(username="doesnotexist")
+
+    assert execinfo.value.status == 400
+    assert execinfo.value.payload_str == "User doesnotexist not known"
+
+
+##################################################
 # Error paths of the changeset operations        #
 ##################################################
 

--- a/tests/fixtures/test_changeset_comments_search.xml
+++ b/tests/fixtures/test_changeset_comments_search.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="OpenStreetMap server" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+  <comment id="3011" date="2025-02-14T09:12:33Z" visible="true" uid="1841" user="metaodi">
+    <text>Thanks for the fix!</text>
+  </comment>
+  <comment id="2984" date="2025-02-13T17:04:10Z" visible="true" uid="1841" user="metaodi">
+    <text>Did you verify those street names?</text>
+  </comment>
+  <comment id="2971" date="2025-02-12T08:45:59Z" visible="true">
+    <text>Comment of an author without public data</text>
+  </comment>
+</osm>

--- a/tests/fixtures/test_changeset_comments_search_empty_result.xml
+++ b/tests/fixtures/test_changeset_comments_search_empty_result.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="OpenStreetMap server" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+</osm>

--- a/tests/fixtures/test_changeset_comments_search_unknown_user.xml
+++ b/tests/fixtures/test_changeset_comments_search_unknown_user.xml
@@ -1,0 +1,1 @@
+User doesnotexist not known


### PR DESCRIPTION
Wraps GET /api/0.6/changeset_comments, which OpenStreetMap added in
February 2025 (openstreetmap-website#4359). Unlike changeset_get with
include_discussion=True, which returns the discussion of a single
changeset, this searches the comments of all changesets.

Supports filtering by author (userid/username -> user/display_name) and
by creation time (created_after/created_before -> from/to), plus an
optional limit. The API ignores an upper time bound without a lower one,
so created_after defaults to the epoch when only created_before is
given, mirroring what changesets_get already does for its time range.

The response uses the same <comment> element as the changeset
discussion, so the per-comment parsing is extracted from
_dom_get_discussion into a new dom.dom_parse_comment helper and reused.

Fixes #220

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RAMhU62xQjrmEZzVbT2ndH