### PR TITLE
Raise requests floor to 2.33.0 to resolve Dependabot alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Changed
 - Request bodies are now assembled with `xml.etree.ElementTree` instead of by concatenating strings, so escaping is handled by the standard library (see issue #56). The generated XML is unchanged apart from formatting
+- Raise the minimum `requests` version from `2.25.0` to `2.33.0`, which fixes [GHSA-9hjg-9r4m-mvj7](https://github.com/psf/requests/security/advisories/GHSA-9hjg-9r4m-mvj7) (a predictable temp file name in `requests.utils.extract_zipped_paths`, a function osmapi does not call, but the old floor still let Dependabot flag the declared range)
 
 ### Fixed
 - Fix tag values and member roles containing a newline, a tab or a carriage return being silently corrupted on write (`node_update`, `way_create`, `relation_delete`, `changeset_create`, `changeset_upload`, …). Those characters were written literally into an XML attribute, where the parser on the other end normalizes them to a space, so `{"note": "first\nsecond"}` arrived at the API as `"first second"`. They are now written as character references and round-trip unchanged. Member `type` was not escaped at all (see issue #216)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ classifiers = [
 # Lower bound only: osmapi only uses the long-stable parts of the requests API
 # (Session, Session.request and the exception classes). Never add an upper bound
 # here, a cap in a library propagates into every downstream resolver.
-dependencies = ["requests>=2.25.0"]
+# >=2.33.0 for GHSA-9hjg-9r4m-mvj7 (predictable temp file in extract_zipped_paths,
+# not used by osmapi, but the floor is what Dependabot tracks).
+dependencies = ["requests>=2.33.0"]
 dynamic = ["version"]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -364,7 +364,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -744,7 +744,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.25.0" }]
+requires-dist = [{ name = "requests", specifier = ">=2.33.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
The declared requests>=2.25.0 lower bound let pip resolve a version
vulnerable to GHSA-9hjg-9r4m-mvj7 (predictable temp file name in
extract_zipped_paths, unused by osmapi). Bumping the floor to 2.33.0
closes the alert; uv.lock already had 2.34.2 so only the metadata
constraint changes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XJ75TszctN57f9x4d7bLWr